### PR TITLE
Test enhancement

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,8 +20,7 @@ build:
             #- shellcheck-run -s bash $(ls scripts/*/*.sh)
             #- csslint-run --exclude-list=public_html/css/domains.css,public_html/css/minified,public_html/css/reset.css,public_html/css/price_win.css public_html/css
             -
-                command: 'vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/ -v --coverage-clover coverage.xml --whitelist src/'
-                #command: 'phpdbg -qrr vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/ -v --coverage-clover coverage.xml --whitelist src/'
+                command: 'vendor/bin/phpunit tests/ -v --coverage-clover coverage.xml --whitelist src/'
                 coverage:
                     file: 'coverage.xml'
                     format: 'clover'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 cache:
   directories:
     - $HOME/.composer/cache/files
@@ -26,8 +27,8 @@ before_script:
   - travis_retry composer self-update
   - travis_retry composer update --with-dependencies --no-interaction --dev --prefer-dist
 script: 
-  - if [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then phpdbg -qrr vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/ -v --coverage-clover coverage.xml --whitelist src/; fi;
-  - if [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/ -v; fi
+  - if [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then phpdbg -qrr vendor/bin/phpunit tests/ -v --coverage-clover coverage.xml --whitelist src/; fi;
+  - if [ "$TRAVIS_PHP_VERSION" != "7.0" ]; then vendor/bin/phpunit tests/ -v; fi
 after_success:
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then travis_retry vendor/bin/test-reporter --coverage-report=coverage.xml; fi
   - if [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then travis_retry bash <(curl -s https://codecov.io/bash); fi;

--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,11 @@
 		}
 	},
 	"require": {
-		"php": ">=5.3.2",
+		"php": ">=5.4",
 		"roave/security-advisories": "dev-master"
 	},
 	"require-dev": {
-		"phpunit/phpunit": ">=4.8.35, <6.0.0",
-		"phpunit/phpunit-mock-objects": "*"
+		"phpunit/phpunit": "^4.8.35 | ^5.5 | ^6.5"
 	},
 	"extra": {
 		"branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,14 +8,14 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="./tests/bootstrap.php"
+         bootstrap="./vendor/autoload.php"
 >
   <logging>
     <log type="coverage-clover" target="build/logs/clover.xml"/>
   </logging>
   <filter>
     <whitelist processUncoveredFilesFromWhitelist="true" addUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">/src</directory>
+      <directory suffix=".php">./src</directory>
     </whitelist>
   </filter>
     <testsuites>

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -13,7 +13,7 @@ namespace Detain\ZipZapper;
  * @author Joe Huss <detain@interserver.net>
  */
 class Validator {
-	protected $zip_names = [
+	protected $zipNames = [
 		'BR' => ['name' => 'CEP', 'acronym_text' => 'Código de endereçamento postal (Postal Addressing Code)'],
 		'CA' => ['name' => 'Postal Code', 'acronym_text' => ''],
 		'CH' => ['name' => 'NPA', 'acronym_text' => "numéro postal d'acheminement in French-speaking Switzerland and numéro postal d'acheminement in Italian-speaking Switzerland"],

--- a/tests/Detain/Tests/ZipZapper/ValidatorTest.php
+++ b/tests/Detain/Tests/ZipZapper/ValidatorTest.php
@@ -2,14 +2,15 @@
 
 namespace Detain\Tests\ZipZapper;
 
-use \Detain\ZipZapper\Validator;
+use Detain\ZipZapper\Validator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ValidatorTest
  *
  * @package Detain\Tests\ZipZapper
  */
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
 
     /**
@@ -105,7 +106,30 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function testZipName()
     {
         $validator = new Validator();
-        $this->assertEquals($validator->getZipName('US'), 'Postal Code');
+        $this->assertEquals('ZIP code', $validator->getZipName('US'));
+        $this->assertEquals('Postal Code', $validator->getZipName('invalid_country_code'));
+    }
+
+    public function testGetFormats()
+    {
+        $validator = new Validator();
+        $this->assertEquals(['#####', '#####-####'], $validator->getFormats('US'));
+    }
+
+    /**
+     * @expectedException Detain\ZipZapper\ValidationException 
+     */
+    public function testGetFormatsWithInvalidCountryCode()
+    {
+        $validator = new Validator();
+        $validator->getFormats('invalid_country_code');
+    }
+
+    public function testHasCountry()
+    {
+        $validator = new Validator();
+        $this->assertTrue($validator->hasCountry('US'));
+        $this->assertFalse($validator->hasCountry('invalid_country_code'));
     }
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,0 @@
-<?php
-require_once __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
# Changed log

- Let the package require ```php-5.3``` version at least.
- Remove the ```bootstrap.php``` file because it can set the ```vendor/autoload.php``` directly in ```phpunit.xml``` setting.
- Add more tests.
- Set the multiple PHPUnit versions to support the different PHP versions.
- Use the class-based ```PHPUnit\Framework\TestCase``` to be compatible with the latest PHPUnit version.